### PR TITLE
add support for enterprise Github by providing a configurable github url

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Prometheus metrics exporter for github actions self-hosted runners.
 | OWNER                | Yes      | Github organization name
 | REFRESH_INTERVAL     | No       | Internval time in seconds betwen api requests (Default: 20)
 | LOG_LEVEL            | No       | Log level: DEBUG, INFO, WARNING or ERROR (Default: INFO)
+| API_URL              | No       | URL to your github API (Default: https://api.github.com)
 
 
 ## How to deploy

--- a/runner_exporter/github_api.py
+++ b/runner_exporter/github_api.py
@@ -40,9 +40,6 @@ class githubApi:
         self.github_owner = github_owner
         self.logger = logger
 
-        if api_url != "":
-            self.api_url = api_url
-
     def app_jwt_header(self):
         """
         Creates a JSON Web Token (JWT) for authorization to be used with the GitHub API.

--- a/runner_exporter/github_api.py
+++ b/runner_exporter/github_api.py
@@ -22,6 +22,7 @@ class githubApi:
         github_token: str = None,
         github_app_id: str = None,
         private_key: str = None,
+        api_url: str = "https://api.github.com",
     ) -> None:
 
         if github_owner is None or github_owner.strip() == "":
@@ -37,6 +38,7 @@ class githubApi:
         self.github_app_id = github_app_id
         self.private_key = private_key
         self.github_owner = github_owner
+        self.api_url = api_url
         self.logger = logger
 
     def app_jwt_header(self):
@@ -71,8 +73,6 @@ class githubApi:
         Returns:
             str: The app token for use with the GitHub API
         """
-        api_url = "https://api.github.com"
-
         if self.app_token_expire_at:
             expires_at = datetime.datetime.strptime(
                 self.app_token_expire_at, "%Y-%m-%dT%H:%M:%SZ"
@@ -89,7 +89,7 @@ class githubApi:
 
         try:
             instalations_response = requests.get(
-                f"{api_url}/app/installations", headers=jwt_headers
+                f"{self.api_url}/app/installations", headers=jwt_headers
             )
             instalations_response.raise_for_status()
             instalations = instalations_response.json()
@@ -99,7 +99,7 @@ class githubApi:
 
         try:
             resp = requests.post(
-                f'{api_url}/app/installations/{instalations[0]["id"]}/access_tokens',
+                f'{self.api_url}/app/installations/{instalations[0]["id"]}/access_tokens',
                 headers=jwt_headers,
             )
             resp.raise_for_status()

--- a/runner_exporter/github_api.py
+++ b/runner_exporter/github_api.py
@@ -38,8 +38,10 @@ class githubApi:
         self.github_app_id = github_app_id
         self.private_key = private_key
         self.github_owner = github_owner
-        self.api_url = api_url
         self.logger = logger
+
+        if api_url != "":
+            self.api_url = api_url
 
     def app_jwt_header(self):
         """

--- a/runner_exporter/runner_exporter.py
+++ b/runner_exporter/runner_exporter.py
@@ -164,6 +164,9 @@ def main():
 
     runner_exports = runnerExports()
 
+    if API_URL == None or API_URL == "":
+        API_URL = "https://api.github.com"
+
     github = githubApi(
         OWNER,
         logger,

--- a/runner_exporter/runner_exporter.py
+++ b/runner_exporter/runner_exporter.py
@@ -170,6 +170,7 @@ def main():
         github_token=PRIVATE_GITHUB_TOKEN,
         github_app_id=GITHUB_APP_ID,
         private_key=GITHUB_PRIVATE_KEY,
+        api_url=API_URL,
     )
 
     while True:

--- a/runner_exporter/runner_exporter.py
+++ b/runner_exporter/runner_exporter.py
@@ -156,6 +156,7 @@ def main():
     GITHUB_APP_ID = os.getenv("GITHUB_APP_ID")
     GITHUB_PRIVATE_KEY = os.getenv("GITHUB_PRIVATE_KEY")
     OWNER = os.getenv("OWNER")
+    API_URL = os.getenv("API_URL")
 
     # Start prometheus metrics
     logger.info("Starting metrics server")


### PR DESCRIPTION
This PR provides configuration to the github api url, keeping the default of https://api.github.com, but providing configuration through an env var, `API_URL` so that enterprise github users can configure this to point to their instances