### PR TITLE
Additional changes for Github enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Prometheus metrics exporter for github actions self-hosted runners.
 | REFRESH_INTERVAL     | No       | Internval time in seconds betwen api requests (Default: 20)
 | LOG_LEVEL            | No       | Log level: DEBUG, INFO, WARNING or ERROR (Default: INFO)
 | API_URL              | No       | URL to your github API (Default: https://api.github.com)
+| GITHUB_APP_ID        | No       | The Github app id to login as
+| GITHUB_PRIVATE_KEY   | No*      | The Github app private key generated from the app settings
 
 
 ## How to deploy

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Prometheus metrics exporter for github actions self-hosted runners.
 | LOG_LEVEL            | No       | Log level: DEBUG, INFO, WARNING or ERROR (Default: INFO)
 | API_URL              | No       | URL to your github API (Default: https://api.github.com)
 | GITHUB_APP_ID        | No       | The Github app id to login as
-| GITHUB_PRIVATE_KEY   | No*      | The Github app private key generated from the app settings
+| GITHUB_PRIVATE_KEY   | No*      | The Github app private key generated from the app settings, required if GITHUB_APP_ID is set
 
 
 ## How to deploy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
+cryptography==42.0.5
 prometheus_client==0.15.0
 requests==2.28.2
-PyJWT==2.6.0
+PyJWT==2.8.0
 python-dateutil==2.8.1

--- a/runner_exporter/github_api.py
+++ b/runner_exporter/github_api.py
@@ -38,6 +38,7 @@ class githubApi:
         self.github_app_id = github_app_id
         self.private_key = private_key
         self.github_owner = github_owner
+        self.api_url = api_url
         self.logger = logger
 
     def app_jwt_header(self):
@@ -152,7 +153,7 @@ class githubApi:
         headers = self.get_headers()
 
         per_page = 100
-        url = f"https://api.github.com/orgs/{self.github_owner}/actions/runners?per_page={per_page}"
+        url = f"{self.api_url}/orgs/{self.github_owner}/actions/runners?per_page={per_page}"
 
         while True:
             try:

--- a/runner_exporter/runner_exporter.py
+++ b/runner_exporter/runner_exporter.py
@@ -156,16 +156,13 @@ def main():
     GITHUB_APP_ID = os.getenv("GITHUB_APP_ID")
     GITHUB_PRIVATE_KEY = os.getenv("GITHUB_PRIVATE_KEY")
     OWNER = os.getenv("OWNER")
-    API_URL = os.getenv("API_URL")
+    API_URL = os.getenv("API_URL", "https://api.github.com")
 
     # Start prometheus metrics
     logger.info("Starting metrics server")
     start_http_server(8000)
 
     runner_exports = runnerExports()
-
-    if API_URL == None or API_URL == "":
-        API_URL = "https://api.github.com"
 
     github = githubApi(
         OWNER,


### PR DESCRIPTION
Hey @tchelovilar 

> TL;DR
>
> update `README` to include info about github app id and private key
> update `API_URL` to match pattern for `os.getenv` to set a default
> update `github_api` to use `API_URL` when formatting the url it uses for getting the runner info

Thank you for your help last week. In running this, I found that I missed the core call formatting for the `url` in `github_api.py` 🤦 

I've since worked through it locally and resolved some of these issues, I tested locally with some `print` debug (which I've removed) to ensure formatting was correct and changes were functioning as expected. Because I don't have org owner on the org I'm testing against, I'm still getting permission issues but that's to be expected I think. Here's two tests:

Default path:

```sh
OWNER="MYORG" PRIVATE_GITHUB_TOKEN=$GITHUB_TOKEN python3 -u runner_exporter.py
INFO:root:Starting metrics server
https://api.github.com/orgs/MYORG/actions/runners?per_page=100
Found runners: []
```

GHE path:

```sh
API_URL="https://github.myenterprise.com/api/v3" OWNER="MYORG" GITHUB_APP_ID=42 GITHUB_PRIVATE_KEY=`cat /path/to/private-key.pem` python3 -u runner_exporter.py
INFO:root:Starting metrics server
API_URL: https://github-it.tesla.com/api/v3
INFO:root:A new app token has been generated. It will expire on 2024-04-01T22:04:22Z
Fetching https://github.myenterprise.com/api/v3/orgs/MYORG/actions/runners?per_page=100
ERROR:root:Api request returned error: Forbidden {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/enterprise-server@3.12/rest/actions/self-hosted-runners#list-self-hosted-runners-for-an-organization"}
```

With this, I think everything should be set, would you agree?
